### PR TITLE
Typo

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -522,12 +522,12 @@ The lifecycle MUST set the name of the environment variable to the name of the f
 
 If the environment variable has no period-delimited suffix, then the value of the environment variable MUST be a concatenation of the file contents and the contents of other identically named files in other `<cache>/<layer>/env/` directories delimited by the OS path list separator.
 Within that environment variable value,
-- Earlier buildpacks' environment variable file contents MUST proceed later buildpacks' environment variable file contents.
+- Earlier buildpacks' environment variable file contents MUST precede later buildpacks' environment variable file contents.
 - Environment variable file contents originating from the same buildpack MUST be sorted alphabetically ascending by associated layer name.
 
 If the environment variable file name ends in `.append`, then the value of the environment variable MUST be a concatenation of the file contents and the contents of other identically named files in other `<cache>/<layer>/env/` directories without any delimitation.
 Within that environment variable value,
-- Earlier buildpacks' environment variable file contents MUST proceed later buildpacks' environment variable file contents.
+- Earlier buildpacks' environment variable file contents MUST precede later buildpacks' environment variable file contents.
 - Environment variable file contents originating from the same buildpack MUST be sorted alphabetically ascending by associated layer name.
 
 If the environment variable file name ends in `.override`, then the value of the environment variable MUST be the file contents or the contents of another identically named file in another `<cache>/<layer>/env/` directory.


### PR DESCRIPTION
This change fixes a typo where proceed was used instead of a precede.