### PR TITLE
Move layer argument to $1 for bin/build and bin/develop

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -89,7 +89,7 @@ Executable: `/bin/detect <platform[AR]> <plan[E]>`, Working Dir: `<app[AR]>`
 
 ###  Build
 
-Executable: `/bin/build <platform[AR]> <plan[E]> <layers[EIC]>`, Working Dir: `<app[AI]>`
+Executable: `/bin/build <layers[EIC]> <platform[AR]> <plan[E]>`, Working Dir: `<app[AI]>`
 
 | Input             | Description
 |-------------------|----------------------------------------------
@@ -118,7 +118,7 @@ Executable: `/bin/build <platform[AR]> <plan[E]> <layers[EIC]>`, Working Dir: `<
 
 ### Development
 
-Executable: `/bin/develop <platform[AR]> <plan[E]> <layers[EC]>`, Working Dir: `<app[A]>`
+Executable: `/bin/develop <layers[EC]> <platform[AR]> <plan[E]>`, Working Dir: `<app[A]>`
 
 | Input             | Description
 |-------------------|----------------------------------------------


### PR DESCRIPTION
As described in #28, this change moves the `<layers[EIC]>` argument to the `$1` position for both `bin/build` and `bin/develop`.